### PR TITLE
Replaced empty `print()` with newline `\n` & reworded some of the exceptions

### DIFF
--- a/example_reasons.py
+++ b/example_reasons.py
@@ -6,6 +6,5 @@ eth_address_1 = "0xbb0ea877a85df253ccc312b80c644da31443abfd"
 report = riskreport_on_entity(eth_addresses=[eth_address_1])
 
 for reason in report.reasons:
-    print()
-    print(f"The following contributed to the score by: {reason.offsets.combined_risk_offset}")
+    print(f"\nThe following contributed to the score by: {reason.offsets.combined_risk_offset}")
     print(reason.explanation)

--- a/januus_riskreport/exceptions.py
+++ b/januus_riskreport/exceptions.py
@@ -7,12 +7,12 @@ class RiskReportException(Exception):
 class DeserializationException(RiskReportException):
 
     def __init__(self, msg: str):
-        self.message = f"\nCould not deserialize the following class: {msg}\nPlease PLEASE contact januus to file a bug" 
+        self.message = f"\nCould not deserialize the following class: {msg}\nPlease contact januus to file a bug report." 
         super().__init__(self.message)
 
 class UnknownLabelException(RiskReportException):
     def __init__(self, msg: str):
-        self.message = f"Unknown label: {msg}\nPlease PLEASE contact januus to file a bug" 
+        self.message = f"Unknown label: {msg}\nPlease contact januus to file a bug report." 
         super().__init__(self.message)
 
 
@@ -23,5 +23,5 @@ class EndPointException(RiskReportException):
 
 class RequestedNullReport(RiskReportException):
     def __init__(self):
-        self.message = "You asked for a risk report but didn't provide any data about the entity. Try adding 'eth_addresses' or 'btc_addresses'" 
+        self.message = "A wallet address needs to be entered. Try adding an 'eth_addresses' or 'btc_addresses'." 
         super().__init__(self.message)


### PR DESCRIPTION
- Replaced an empty `print()` with a newline character, `\n`.
   - Code in other modules uses the `\n` character to set a newline; edit helps with uniformity.
- Reworded exception messages.
   - Improved the tone of the exception messages the end-user sees. 